### PR TITLE
Fixes yaml loader issue with yaml 6.0

### DIFF
--- a/multiphonon/ui/__init__.py
+++ b/multiphonon/ui/__init__.py
@@ -31,7 +31,7 @@ class Context:
         return
     def from_yaml(self, path):
         with open(path) as stream:
-            d = yaml.load(stream)
+            d = yaml.load(stream,Loader=yaml.FullLoader)
         for k, v in d.items():
             setattr(self, k,v)
             continue

--- a/tests/ui/getdos_TestCase.py
+++ b/tests/ui/getdos_TestCase.py
@@ -16,6 +16,14 @@ from multiphonon.ui import batch
 import unittest
 class TestCase(unittest.TestCase):
 
+    def test_contextload(self):
+        from multiphonon.ui import Context
+        cntxt =  Context()
+        cntxt.to_yaml('context.yaml')
+        cntxt2 = Context()
+        cntxt2.from_yaml('context.yaml')
+        return
+        
     def test1(self):
         "multiphonon.ui.getdos"
         from multiphonon.ui import getdos


### PR DESCRIPTION
This adds the "FullLoader" to the yaml.load method in  Context.from_yaml. This resolves Issue #144 
Could we switch to the "SafeLoader"?